### PR TITLE
Refactor texture class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # Directories
 build
 external
-.vs
-tutorial/Assignment2/glm
 
 # Files

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Directories
 build
 external
+.vs
+tutorial/Assignment2/glm
 
 # Files

--- a/igl/opengl/glfw/Viewer.cpp
+++ b/igl/opengl/glfw/Viewer.cpp
@@ -796,23 +796,18 @@ IGL_INLINE bool
 
     int Viewer::AddTexture(int width, int height, unsigned char* data, int mode)
     {
-        textures.push_back(new Texture(width, height));
-
         switch (mode)
         {
-            case COLOR:
-                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data); //note GL_RED internal format, to save memory.
-                break;
-            case DEPTH:
-                glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, data);
-                break;
-            case STENCIL:
-                glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, width, height, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, data);
-                break;
-            default:
-                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data); //note GL_RED internal format, to save memory.
+        case DEPTH:
+            textures.push_back(new Texture(GL_DEPTH_COMPONENT32, width, height, GL_DEPTH_COMPONENT, GL_FLOAT, data));
+            break;
+        case STENCIL:
+            textures.push_back(new Texture(GL_DEPTH24_STENCIL8, width, height, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, data));
+            break;
+        case COLOR:
+        default:
+            textures.push_back(new Texture(GL_RGBA, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data)); //note GL_RED internal format, to save memory.
         }
-        glBindTexture(GL_TEXTURE_2D, 0);
         return(textures.size() - 1);
     }
 
@@ -826,7 +821,6 @@ IGL_INLINE bool
             s->SetUniformMat4f("Model", Model);
         }
     }
-
 
     void Viewer::SetParent(int indx, int newValue, bool savePosition)
     {

--- a/igl/opengl/glfw/texture.cpp
+++ b/igl/opengl/glfw/texture.cpp
@@ -103,8 +103,3 @@ void Texture::Bind(int slot)
 	glActiveTexture(GL_TEXTURE0 + slot);
 	glBindTexture(m_type, m_texture);
 }
-
-void Texture::Unbind()
-{
-	glBindTexture(m_type, 0);
-}

--- a/igl/opengl/glfw/texture.cpp
+++ b/igl/opengl/glfw/texture.cpp
@@ -3,44 +3,55 @@
 #include "../gl.h"
 #include "stb_image.h"
 #include <iostream>
+#include <cassert>
 
-Texture::Texture(const std::string& fileName, const int dim)
+Texture::Texture(const int dim) : m_dim(dim)
 {
-	int width, height, numComponents;
-	unsigned char* data;
-	
-      
-    glGenTextures(1, &m_texture);
-	texDimention = dim;
-	Bind(m_texture);
+	assert(dim > 0 && dim < 4);
+
 	switch (dim)
 	{
 	case 1:
-		data = stbi_load((fileName).c_str(), &width, &height, &numComponents, 4);
-		if (data == NULL)
-			std::cerr << "Unable to load texture: " << fileName << std::endl;
+		m_type = GL_TEXTURE_1D;
+		break;
+	case 2:
+		m_type = GL_TEXTURE_2D;
+		break;
+	case 3:
+		m_type = GL_TEXTURE_CUBE_MAP;
+		break;
+	}
+}
 
+Texture::Texture(const std::string& fileName, const int dim) : Texture(dim)
+{
+	int width, height, numComponents;
+	unsigned char* pixels = NULL;
+
+	glGenTextures(1, &m_texture);
+	glBindTexture(m_type, m_texture);
+	switch (dim)
+	{
+	case 1:
+		pixels = LoadFromFile(fileName, &width, &height, &numComponents, 4);
 		glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, width, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, width, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 		break;
-	case 2:
-	default:
-		data = stbi_load((fileName).c_str(), &width, &height, &numComponents, 4);
-		if (data == NULL)
-			std::cerr << "Unable to load texture: " << fileName << std::endl;
 
+	case 2: 
+		pixels = LoadFromFile(fileName, &width, &height, &numComponents, 4);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 		glGenerateMipmap(GL_TEXTURE_2D);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.4f);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 		break;
-	case 3://cube map
-		
+
+	case 3: // cube map
 		glGenerateMipmap(GL_TEXTURE_2D);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.4f);
 		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -48,91 +59,52 @@ Texture::Texture(const std::string& fileName, const int dim)
 		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-		std::string directions[] = { "Right","Left","Top","Bottom","Front","Back" };
-		for (int i = 0; i < 6; i++)
 		{
-			data = stbi_load((fileName + directions[i] + ".bmp").c_str(), &width, &height, &numComponents, 4);
-			if (data == NULL)
-				std::cerr << "Unable to load texture: " << fileName << std::endl;
-
-			glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+			std::string directions[] = { "Right","Left","Top","Bottom","Front","Back" };
+			for (int i = 0; i < 6; i++)
+			{
+				pixels = LoadFromFile(fileName + directions[i] + ".bmp", &width, &height, &numComponents, 4);
+				glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+			}
 		}
+		break;
 	}
-	stbi_image_free(data);
+	glBindTexture(m_type, 0);
+	stbi_image_free(pixels);
 }
 
-Texture::Texture(int width,int height,unsigned char *data)
+Texture::Texture(int internalformat, int width, int height, unsigned int format, unsigned int type, const void* data) : Texture(height > 0 ? 2 : 1)
 {
 	glGenTextures(1, &m_texture);
-	if (height > 0)
-	{
-		texDimention = 2;
-		Bind(m_texture);
-
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		//glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-	}
-	else
-	{ 
-		texDimention = 1;
-		Bind(m_texture);
-		glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, width, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-	}	
+	glBindTexture(m_type, m_texture);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+	if (m_dim == 2) glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexImage2D(GL_TEXTURE_2D, 0, internalformat, width, height, 0, format, type, data);
+	glBindTexture(m_type, 0);
 }
-
-Texture::Texture(int width, int height)
-{
-	glGenTextures(1, &m_texture);
-	if (height > 0)
-	{
-		texDimention = 2;
-		Bind(m_texture);
-
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	}
-	else
-	{
-		texDimention = 1;
-		Bind(m_texture);
-		glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
-	}
-}
-
 
 Texture::~Texture()
 {
 	glDeleteTextures(1, &m_texture);
 }
 
+unsigned char* Texture::LoadFromFile(const std::string& fileName, int* width, int* height, int* numComponents, int reqComponents)
+{
+	unsigned char* data = stbi_load(fileName.c_str(), width, height, numComponents, reqComponents);
+	if (data == NULL)
+		throw new std::runtime_error(fileName + " stbi_load error");
+	return data;
+}
+
 void Texture::Bind(int slot)
 {
 	glActiveTexture(GL_TEXTURE0 + slot);
-	switch (texDimention)
-	{
-	case 1:
-		glBindTexture(GL_TEXTURE_1D, m_texture);
-		break;
-	case 2:
-	default:
-		//int tex = 1;
-		glBindTexture(GL_TEXTURE_2D, m_texture);
-	case 3:
-		glBindTexture(GL_TEXTURE_CUBE_MAP, m_texture);
-	}
+	glBindTexture(m_type, m_texture);
 }
 
-
+void Texture::Unbind()
+{
+	glBindTexture(m_type, 0);
+}

--- a/igl/opengl/glfw/texture.cpp
+++ b/igl/opengl/glfw/texture.cpp
@@ -26,29 +26,29 @@ Texture::Texture(const int dim) : m_dim(dim)
 Texture::Texture(const std::string& fileName, const int dim) : Texture(dim)
 {
 	int width, height, numComponents;
-	unsigned char* pixels = NULL;
+	unsigned char* data = NULL;
 
 	glGenTextures(1, &m_texture);
 	glBindTexture(m_type, m_texture);
 	switch (dim)
 	{
 	case 1:
-		pixels = LoadFromFile(fileName, &width, &height, &numComponents, 4);
+		data = LoadFromFile(fileName, &width, &height, &numComponents, 4);
 		glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameterf(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, width, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+		glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, width, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 		break;
 
 	case 2: 
-		pixels = LoadFromFile(fileName, &width, &height, &numComponents, 4);
+		data = LoadFromFile(fileName, &width, &height, &numComponents, 4);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 		glGenerateMipmap(GL_TEXTURE_2D);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.4f);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 		break;
 
 	case 3: // cube map
@@ -63,14 +63,14 @@ Texture::Texture(const std::string& fileName, const int dim) : Texture(dim)
 			std::string directions[] = { "Right","Left","Top","Bottom","Front","Back" };
 			for (int i = 0; i < 6; i++)
 			{
-				pixels = LoadFromFile(fileName + directions[i] + ".bmp", &width, &height, &numComponents, 4);
-				glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+				data = LoadFromFile(fileName + directions[i] + ".bmp", &width, &height, &numComponents, 4);
+				glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 			}
 		}
 		break;
 	}
 	glBindTexture(m_type, 0);
-	stbi_image_free(pixels);
+	stbi_image_free(data);
 }
 
 Texture::Texture(int internalformat, int width, int height, unsigned int format, unsigned int type, const void* data) : Texture(height > 0 ? 2 : 1)

--- a/igl/opengl/glfw/texture.h
+++ b/igl/opengl/glfw/texture.h
@@ -9,7 +9,6 @@ public:
 	Texture(int internalformat, int width, int height, unsigned int format, unsigned int type, const void* data);
 	 ~Texture();
 	 void Bind(int slot);
-	 void Unbind();
 
 private:
 

--- a/igl/opengl/glfw/texture.h
+++ b/igl/opengl/glfw/texture.h
@@ -1,24 +1,22 @@
-#ifndef TEXTURE_H
-#define TEXTURE_H
-
+#pragma once
 #include <string>
 
 class Texture
 {
 public:
-	Texture(const std::string& fileName,const int dim);
-	Texture(int width, int height,unsigned char *data);
-	Texture(int width, int height);
-	void Bind(int slot);
 
-	inline int GetSlot(){return m_texture;}
+	Texture(const std::string& fileName, const int dim);
+	Texture(int internalformat, int width, int height, unsigned int format, unsigned int type, const void* data);
 	 ~Texture();
-protected:
-private:
-	//Texture(const Texture& texture) {}
-	void operator=(const Texture& texture) {}
-	unsigned int m_texture;
-	int texDimention;
-};
+	 void Bind(int slot);
+	 void Unbind();
 
-#endif
+private:
+
+	unsigned char* LoadFromFile(const std::string& filename, int* width, int* height, int* numComponents, int reqComponents);
+	Texture(int dim); // private constructor to initialize m_type
+
+	unsigned int m_texture = 0;
+	int m_dim;
+	int m_type = 0;
+};


### PR DESCRIPTION
Refactored the textures according to the changes we discussed in the meeting:
1. Fixed the problem with the number of textures being limited to 31.
2. Removed unnecessary call to glActiveTexture after glGenTextures
3. Rearrange the code 
4. Consolidated duplicate and/or redundant code